### PR TITLE
Fix OOM due to update avalanches

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ Internal class used to automatically update databases, exposed to allow advanced
    - `update` Emitted when new databases have been written to the filesystem.
  - **Methods**
    - *checkUpdates()* Checks for new database updates and downloads them.
-   - *triggerUpdate()* Replaces the current databases with fresh copies from the mirror.
    - *close()* Shuts down the updater.
  - **Props**
+   - `checking`: `<boolean>` Whether databases are being checked for updates in the background right now - see `checking` event.
    - `downloading`: `<boolean>` Whether databases are being downloaded in the background right now - see `downloading` event.
 
 ## Warning

--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ class UpdateSubscriber extends EventEmitter {
 		}
 		finally {
 			this.checking = false;
+			this.emit('done checking');
 		}
 	}
 

--- a/scripts/download-helper.js
+++ b/scripts/download-helper.js
@@ -99,8 +99,9 @@ function verifyAllChecksums(downloadPath) {
 	const promises = editions.map(edition => {
 		return new Promise((resolve, reject) => {
 			fs.readFile(path.join(downloadPath, edition.name + '.mmdb'), (err, buffer) => {
-				if (err) {
+				if (err || typeof buffer === 'undefined') {
 					reject(err);
+					return;
 				}
 
 				const checksum = crypto.createHash('sha384').update(buffer, 'binary', 'hex').digest('hex');

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const fs = require('fs');
 const geolite2 = require('../');
+const rimraf = require('rimraf');
 const maxmind = require('maxmind');
 
 describe('geolite2', function() {
@@ -41,9 +42,11 @@ describe('geolite2.UpdateSubscriber', function() {
   describe('#checkUpdates()', function() {
     it('should be able to check updates again', function() {
       return new Promise((resolve, reject) => {
-        updateSubscriber.checkUpdates();
-        updateSubscriber.once('checking', () => {
-          resolve();
+        updateSubscriber.once('done checking', () => {
+          updateSubscriber.checkUpdates();
+          updateSubscriber.once('checking', () => {
+            resolve();
+          });
         });
       });
     });
@@ -60,10 +63,15 @@ describe('geolite2.UpdateSubscriber', function() {
           });
         } else {
           // Trigger download
-          updateSubscriber.triggerUpdate();
-          updateSubscriber.once('downloading', () => {
-            updateSubscriber.once('update', () => {
-              resolve();
+          updateSubscriber.once('done checking', () => {
+            rimraf(require('path').resolve(__dirname, '../dbs'), e => {
+              if (e) throw(e);
+              updateSubscriber.checkUpdates();
+              updateSubscriber.once('downloading', () => {
+                updateSubscriber.once('update', () => {
+                  resolve();
+                });
+              });
             });
           });
         }
@@ -123,17 +131,19 @@ describe('geolite2.open', function() {
 
       lookup._test_reader_replacement = 'control';
 
-      assert(lookup._geolite2_triggerUpdate === 'OK');
-
       return new Promise((resolve, reject) => {
-        lookup._geolite2_subscriber.once('update', () => {
-          setTimeout(() => {
-            if (lookup._test_reader_replacement === 'control') {
-              reject(new Error('Reader instance wasn\'t updated'));
-            } else {
-              resolve();
-            }
-          }, 500);
+        rimraf(require('path').resolve(__dirname, '../dbs'), e => {
+          if (e) throw(e);
+          assert(lookup._geolite2_triggerUpdateCheck === 'OK');
+          lookup._geolite2_subscriber.once('update', () => {
+            setTimeout(() => {
+              if (lookup._test_reader_replacement === 'control') {
+                reject(new Error('Reader instance wasn\'t updated'));
+              } else {
+                resolve();
+              }
+            }, 500);
+          });
         });
       });
     });
@@ -175,17 +185,19 @@ describe('geolite2.open', function() {
 
       lookup._test_reader_replacement = 'control';
 
-      assert(lookup._geolite2_triggerUpdate === 'OK');
-
       return new Promise((resolve, reject) => {
-        lookup._geolite2_subscriber.once('update', () => {
-          setTimeout(() => {
-            if (lookup._test_reader_replacement === 'control') {
-              reject(new Error('Reader instance wasn\'t updated'));
-            } else {
-              resolve();
-            }
-          }, 500);
+        rimraf(require('path').resolve(__dirname, '../dbs'), e => {
+          if (e) throw(e);
+          assert(lookup._geolite2_triggerUpdateCheck === 'OK');
+          lookup._geolite2_subscriber.once('update', () => {
+            setTimeout(() => {
+              if (lookup._test_reader_replacement === 'control') {
+                reject(new Error('Reader instance wasn\'t updated'));
+              } else {
+                resolve();
+              }
+            }, 500);
+          });
         });
       });
     });


### PR DESCRIPTION
## Problem

* The proxy object checks if `Date.now() - proxyObject.lastUpdateCheck > updateTimer` on every property access.
* `lastUpdateCheck` starts out as 0 and is only updated on receiving a `checking` event.
* The `checking` event is delayed by at least 200 ms in `.checkUpdates()` (running after`_wait(200)`) 
* Therefore the above check holds true at least for the first 200ms of the process (or a little more, until the checking event is actually done emitting)
* Therefore causing an avalanche of checkUpdates() running in "parallel", once for every property access on that proxied object while `lastUpdateCheck` is still 0 during those first 200ms.

## Result
Process went up to consume 20GB of physical memory, swapping out most the physical memory of most other processes and eventually getting OOM killed by the kernel. Oops.

## Fix
Remove the `lastUpdateCheck/checkUpdates()` calls from the proxy object completely. The `UpdateSubscriber` will perform these anyway already. No need to have this triggered on property access, kinda redundant.

Also, move out the `proxyObject.subscriber` setup from the proxy `get` into the main `wrapReader` body. No need to permanently check the creation when it's created exactly once anyway.

Also, `triggerUpdate()` is useless; stubbed.