### PR TITLE
fix(types): Move downloadDbs to root

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ import { Reader } from "maxmind";
 
 declare module "geolite2-redist" {
   export const databases: string[]
+  export const downloadDbs: (path?: string) => Promise<void>;
   export const open:
     <T>(database: string, readerBuilder: (database: string) =>
       (Reader<T> | Promise<Reader<T>>)) => Promise<Reader<T>>
@@ -10,7 +11,6 @@ declare module "geolite2-redist" {
     public downloading: boolean;
     private _checker: ReturnType<typeof setTimeout>;
 
-    downloadDbs(path?: string): Promise<void>;
     checkUpdates(): Promise<void>;
     update(): void;
     triggerUpdate(): Promise<void>;


### PR DESCRIPTION
Currently, the TypeScript declaration file has the `downloadDbs` function as part of the event emitter, when it should be part of `geolite2`.