### PR TITLE
fix(download): prevent crashing race condition

### DIFF
--- a/src/download-helpers.ts
+++ b/src/download-helpers.ts
@@ -13,6 +13,8 @@ import { GeoIpDbName, Path, Checksum } from './primitives.js'
 
 const REDIST_MIRROR_URL = 'https://raw.githubusercontent.com/GitSquared/node-geolite2-redist/master/redist/'
 
+const pRimraf = promisify(rimraf)
+
 interface MirrorUrls {
 	checksum: Record<GeoIpDbName, string>;
 	download: Record<GeoIpDbName, string>;
@@ -34,9 +36,7 @@ const mirrorUrls: MirrorUrls = {
 const defaultTargetDownloadDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'dbs')
 
 export async function cleanupHotDownloadDir(dirPath?: Path): Promise<void> {
-	rimraf(dirPath ?? defaultTargetDownloadDir+'.geodownload', { disableGlob: true }, (e) => {
-		if (e) throw(e)
-	})
+	return pRimraf(dirPath ?? defaultTargetDownloadDir+'.geodownload', { disableGlob: true })
 }
 
 export async function fetchChecksums(dbList: undefined): Promise<Record<GeoIpDbName, Checksum>>


### PR DESCRIPTION
The `downloadDatabases` function awaits `cleanupHotDownloadDir` under the assumption that the cleanup has finished when the promise resolves.

`cleanupHotDownloadDir` however did not return a promise, as a consequence the `downloadDatabases` does not wait for the actual delete.

We've experienced several instances of our services failing to start because the target directory for the downloads do not exist. This happens when the cleanup happens after the `fs.mkdirSync`. This could happen if cleanup runs slower than the `fs.mkdirSync` call.