### PR TITLE
fix(download): prevent ENOENT races in concurrent environments

### DIFF
--- a/src/auto-updater.ts
+++ b/src/auto-updater.ts
@@ -25,7 +25,7 @@ export class AutoUpdater extends EventEmitter {
 		if (dbList) this.dbList = dbList
 		if (customStorageDir) this.customStorageDir = customStorageDir
 
-		cleanupHotDownloadDir(this.customStorageDir);
+		cleanupHotDownloadDir();
 
 		this.#checker = setInterval(
 			this.checkForUpdates.bind(this),
@@ -69,7 +69,6 @@ export class AutoUpdater extends EventEmitter {
 			console.error(err)
 			console.warn('Warning: allowing the GeoLite databases to self-update is mandatory to comply with license requirements.')
 		} finally {
-			cleanupHotDownloadDir(this.customStorageDir)
 			this.downloading = false
 		}
 	}

--- a/src/download-helpers.ts
+++ b/src/download-helpers.ts
@@ -33,8 +33,26 @@ const mirrorUrls: MirrorUrls = {
 
 const defaultTargetDownloadDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'dbs')
 
-export async function cleanupHotDownloadDir(dirPath?: Path): Promise<boolean> {
-	return rimraf(dirPath ?? defaultTargetDownloadDir+'-tmp', { glob: false })
+export async function cleanupHotDownloadDir(dirPath?: Path): Promise<void> {
+	if (dirPath) {
+		await rimraf(dirPath, { glob: false })
+		return
+	}
+
+	// Clean up any stale temp dirs left over from crashed downloads
+	const parentDir = path.dirname(defaultTargetDownloadDir)
+	const prefix = path.basename(defaultTargetDownloadDir) + '-tmp-'
+	let entries: fs.Dirent[]
+	try {
+		entries = fs.readdirSync(parentDir, { withFileTypes: true })
+	} catch {
+		return
+	}
+	for (const entry of entries) {
+		if (entry.isDirectory() && entry.name.startsWith(prefix)) {
+			await rimraf(path.join(parentDir, entry.name), { glob: false })
+		}
+	}
 }
 
 export async function fetchChecksums(dbList: undefined): Promise<Record<GeoIpDbName, Checksum>>
@@ -101,50 +119,51 @@ export async function downloadDatabases<T extends GeoIpDbName>(dbList?: readonly
 	const dbListToFetch = dbList ?? Object.values(GeoIpDbName)
 	const targetDownloadDir = customStorageDir ?? defaultTargetDownloadDir
 
-	const hotDownloadDir = targetDownloadDir + '-tmp'
-
-	if (fs.existsSync(hotDownloadDir)) {
-		await cleanupHotDownloadDir(hotDownloadDir)
-	}
-
-	fs.mkdirSync(hotDownloadDir)
+	// Use a unique temp dir per download to avoid races between concurrent
+	// processes (e.g. cluster workers) sharing the same node_modules.
+	const hotDownloadDir = fs.mkdtempSync(targetDownloadDir + '-tmp-')
 
 	if (!fs.existsSync(targetDownloadDir)) {
-		fs.mkdirSync(targetDownloadDir)
+		fs.mkdirSync(targetDownloadDir, { recursive: true })
 	}
 
 	const pipeline = promisify(stream.pipeline)
 
-	const downloadedPaths = await Promise.all(
-		dbListToFetch.map(async (dbName): Promise<[T | GeoIpDbName, string]> => [
-			dbName,
-			await (async (): Promise<Path> => {
-				const hotDownloadPath: Path = path.join(hotDownloadDir, `${dbName}.mmdb`)
-				const coldCachePath: Path = path.join(targetDownloadDir, `${dbName}.mmdb`)
+	try {
+		const downloadedPaths = await Promise.all(
+			dbListToFetch.map(async (dbName): Promise<[T | GeoIpDbName, string]> => [
+				dbName,
+				await (async (): Promise<Path> => {
+					const hotDownloadPath: Path = path.join(hotDownloadDir, `${dbName}.mmdb`)
+					const coldCachePath: Path = path.join(targetDownloadDir, `${dbName}.mmdb`)
 
-				const { got } = await import('got')
+					const { got } = await import('got')
 
-				await pipeline(
-					got.stream(mirrorUrls.download[dbName]),
-					tar.x({
-						cwd: hotDownloadDir,
-						filter: (entryPath: Path): boolean => path.basename(entryPath) === `${dbName}.mmdb`,
-						strip: 1
-					})
-				)
+					await pipeline(
+						got.stream(mirrorUrls.download[dbName]),
+						tar.x({
+							cwd: hotDownloadDir,
+							filter: (entryPath: Path): boolean => path.basename(entryPath) === `${dbName}.mmdb`,
+							strip: 1
+						})
+					)
 
-				try {
+					if (!fs.existsSync(hotDownloadPath)) {
+						throw new Error(
+							`Download of ${dbName} failed: database file missing after extraction. `
+							+ 'This can happen when the mirror is rate-limited or the download was interrupted.'
+						)
+					}
+
 					fs.renameSync(hotDownloadPath, coldCachePath)
-				} catch (err) {
-					throw new Error(`Failed to replace ${dbName} with updated version: ${err}`)
-				}
 
-				return coldCachePath
-			})()
-		])
-	)
+					return coldCachePath
+				})()
+			])
+		)
 
-	await cleanupHotDownloadDir(hotDownloadDir)
-
-	return buildObjectFromEntries(downloadedPaths)
+		return buildObjectFromEntries(downloadedPaths)
+	} finally {
+		await cleanupHotDownloadDir(hotDownloadDir)
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #34 — the `ENOENT: no such file or directory, rename` error that affects users running multiple Node.js processes with shared `node_modules` (e.g. cluster workers behind a load balancer).

**Two root causes identified and fixed:**

- **Cross-process race condition**: All processes used the same `dbs-tmp/` temp directory. When two processes triggered a database update simultaneously, one could delete the other's in-progress extraction. Now uses `fs.mkdtempSync` for unique temp directories per download.
- **Silent download failure**: If the GitHub mirror download failed (rate limit, network drop), `tar.x()` with a filter could complete successfully without extracting any files. The subsequent `renameSync` then failed with a confusing ENOENT. Now verifies the extracted file exists before renaming, with a clear error message.

**Also fixed:**
- `cleanupHotDownloadDir()` in the `AutoUpdater` constructor was passing the storage dir itself, which would rimraf the actual database directory (not the temp dir) when a custom path was set.
- Temp dir cleanup now runs in a `finally` block to prevent stale dirs accumulating after errors.

## Test plan

- [ ] `npm run build` passes (verified locally)
- [ ] Single-process download works as before
- [ ] In a cluster environment, concurrent auto-updates no longer race on the temp directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)